### PR TITLE
52 add zip code field to event creation

### DIFF
--- a/EventFinder-UI/src/components/AdminDashboard.jsx
+++ b/EventFinder-UI/src/components/AdminDashboard.jsx
@@ -83,7 +83,10 @@ class AdminDashboard extends Component {
       errors.eventTime = 'Event time is required.';
     }
     if (!editEvent.eventLocation || editEvent.eventLocation.trim() === '') {
-      errors.eventLocation = 'Event location is required.';
+      errors.eventLocation = 'Event venue name is required.';
+    }
+    if (!editEvent.eventLocation || editEvent.eventcityzip.trim() === '') {
+      errors.eventLocation = 'Event zip code is required.';
     }
     if (!editEvent.eventPrice || isNaN(editEvent.eventPrice) || editEvent.eventPrice <= 0) {
       errors.eventPrice = 'Event price must be a positive number.';
@@ -208,7 +211,7 @@ class AdminDashboard extends Component {
                   <th>Event Category</th>
                   <th>Event Date</th>
                   <th>Event Time</th>
-                  <th>Event Location</th>
+                  <th>Event Venue</th>
                   <th>Event City and Zip Code</th>
                   <th>Event Price</th>
                   <th>Approval Status</th>
@@ -301,13 +304,14 @@ class AdminDashboard extends Component {
                     {editErrors.eventTime && <span className="error">{editErrors.eventTime}</span>}
                   </label><br />
                   <label>
-                    Event Location:
+                    Event Venue:
                     <input type="text" name="eventLocation" value={editEvent.eventLocation} onChange={this.handleInputChange} />
                     {editErrors.eventLocation && <span className="error">{editErrors.eventLocation}</span>} 
                   </label><br />
                   <label>
                     Event City and Zip Code:
                     <input type="text" name="eventCityzip" value={editEvent.eventCityzip} onChange={this.handleInputChange} />
+                    {editErrors.eventCityzip && <span className="error">{editErrors.eventCityzip}</span>} 
                   </label><br />
                   <label>
                     Event Price:

--- a/EventFinder-UI/src/components/AdminDashboard.jsx
+++ b/EventFinder-UI/src/components/AdminDashboard.jsx
@@ -85,8 +85,8 @@ class AdminDashboard extends Component {
     if (!editEvent.eventLocation || editEvent.eventLocation.trim() === '') {
       errors.eventLocation = 'Event venue name is required.';
     }
-    if (!editEvent.eventLocation || editEvent.eventcityzip.trim() === '') {
-      errors.eventLocation = 'Event zip code is required.';
+    if (!editEvent.eventCityzip || editEvent.eventcityzip.trim() === '') {
+      errors.eventCityzip = 'Event zip code is required.';
     }
     if (!editEvent.eventPrice || isNaN(editEvent.eventPrice) || editEvent.eventPrice <= 0) {
       errors.eventPrice = 'Event price must be a positive number.';

--- a/EventFinder-UI/src/components/AdminDashboard.jsx
+++ b/EventFinder-UI/src/components/AdminDashboard.jsx
@@ -3,9 +3,13 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import '../styles/AdminDashboard.css';
 import { Link, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import STL_METRO_ZIPS from '../utilities/MetroZipCodes';
+
+const isValidZipCode = (zipCode) => {
+  return STL_METRO_ZIPS.includes(zipCode);
+};
 
 class AdminDashboard extends Component {
-
   
   state = {
     events: [],
@@ -85,8 +89,10 @@ class AdminDashboard extends Component {
     if (!editEvent.eventLocation || editEvent.eventLocation.trim() === '') {
       errors.eventLocation = 'Event venue name is required.';
     }
-    if (!editEvent.eventCityzip || editEvent.eventcityzip.trim() === '') {
+    if (!editEvent.eventCityzip || editEvent.eventCityzip.trim() === '') {
       errors.eventCityzip = 'Event zip code is required.';
+    } else if (!isValidZipCode(editEvent.eventCityzip)) {
+      errors.eventCityzip = 'Please enter a valid zip code from the St. Louis metro area.';
     }
     if (!editEvent.eventPrice || isNaN(editEvent.eventPrice) || editEvent.eventPrice <= 0) {
       errors.eventPrice = 'Event price must be a positive number.';

--- a/EventFinder-UI/src/components/AdminDashboard.jsx
+++ b/EventFinder-UI/src/components/AdminDashboard.jsx
@@ -169,6 +169,7 @@ class AdminDashboard extends Component {
                   <th>Event Date</th>
                   <th>Event Time</th>
                   <th>Event Location</th>
+                  <th>Event City and Zip Code</th>
                   <th>Event Price</th>
                   <th>Approval Status</th>
                   <th>Actions</th>
@@ -184,6 +185,7 @@ class AdminDashboard extends Component {
                     <td>{new Date(event.eventDate).toLocaleDateString()}</td>
                     <td>{this.formatTime(event.eventTime)}</td>
                     <td>{event.eventLocation}</td>
+                    <td>{event.eventCityzip}</td>
                     <td>{event.eventPrice}</td>
                     <td>{event.approvalStatus}</td>
                     <td className='actions'>
@@ -256,6 +258,10 @@ class AdminDashboard extends Component {
                   <label>
                     Event Location:
                     <input type="text" name="eventLocation" value={editEvent.eventLocation} onChange={this.handleInputChange} />
+                  </label><br />
+                  <label>
+                    Event City and Zip Code:
+                    <input type="text" name="eventCityzip" value={editEvent.eventCityzip} onChange={this.handleInputChange} />
                   </label><br />
                   <label>
                     Event Price:

--- a/EventFinder-UI/src/components/CreateEvent.jsx
+++ b/EventFinder-UI/src/components/CreateEvent.jsx
@@ -12,6 +12,7 @@ const CreateEvent = () => {
     event_date: '',
     event_time: '',
     event_location: '',
+    event_cityzip: '',
     event_price: '',
     image: null,
   });
@@ -38,6 +39,7 @@ const CreateEvent = () => {
     formData.append('eventDate', state.event_date);
     formData.append('eventTime', state.event_time);
     formData.append('eventLocation', state.event_location);
+    formData.append('eventCityzip', state.event_cityzip);
     formData.append('eventPrice', state.event_price);
     formData.append('eventImage', state.image);
 
@@ -78,8 +80,12 @@ const CreateEvent = () => {
           <input type="time" name="event_time" value={state.event_time} onChange={handleInputChange} />
         </label>
         <label>
-          Event Location:
+          Event Venue:
           <input type="text" name="event_location" value={state.event_location} onChange={handleInputChange} />
+        </label>
+        <label>
+          Event City and Zip Code:
+          <input type="text" name="event_cityzip" value={state.event_cityzip} onChange={handleInputChange} />
         </label>
         <label>
           Event Price:

--- a/EventFinder-UI/src/components/CreateEvent.jsx
+++ b/EventFinder-UI/src/components/CreateEvent.jsx
@@ -37,7 +37,8 @@ const CreateEvent = () => {
     if (!state.event_category.trim()) newErrors.event_category = 'Event category is required.';
     if (!state.event_date.trim()) newErrors.event_date = 'Event date is required.';
     if (!state.event_time.trim()) newErrors.event_time = 'Event time is required.';
-    if (!state.event_location.trim()) newErrors.event_location = 'Event location is required.';
+    if (!state.event_location.trim()) newErrors.event_location = 'Event venue is required.';
+    if (!state.event_cityzip.trim()) newErrors.event_cityzip = 'Event zip code is required.';
     if (!state.event_price || isNaN(state.event_price) || state.event_price <= 0) {
       newErrors.event_price = 'Event price must be a positive number.';
     }
@@ -146,7 +147,13 @@ const CreateEvent = () => {
         </label>
         <label>
           Event City and Zip Code:
-          <input type="text" name="event_cityzip" value={state.event_cityzip} onChange={handleInputChange} />
+          <input 
+          type="text" 
+          name="event_cityzip" 
+          value={state.event_cityzip} 
+          onChange={handleInputChange}
+          />
+          {errors.event_cityzip && <span className="error">{errors.event_cityzip}</span>}
         </label>
         <label>
           Event Price:

--- a/EventFinder-UI/src/components/CreateEvent.jsx
+++ b/EventFinder-UI/src/components/CreateEvent.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import '../styles/CreateEvent.css';
 import { useNavigate } from 'react-router-dom';
+import STL_METRO_ZIPS from '../utilities/MetroZipCodes';
 
 const CreateEvent = () => {
   const [state, setState] = useState({
@@ -19,6 +20,10 @@ const CreateEvent = () => {
 
   const [errors, setErrors] = useState({});
   const navigate = useNavigate();
+
+  const isValidZipCode = (zipCode) => {
+    return STL_METRO_ZIPS.includes(zipCode);
+  };
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -38,7 +43,11 @@ const CreateEvent = () => {
     if (!state.event_date.trim()) newErrors.event_date = 'Event date is required.';
     if (!state.event_time.trim()) newErrors.event_time = 'Event time is required.';
     if (!state.event_location.trim()) newErrors.event_location = 'Event venue is required.';
-    if (!state.event_cityzip.trim()) newErrors.event_cityzip = 'Event zip code is required.';
+    if (!state.event_cityzip.trim()) {
+      newErrors.event_cityzip = 'Event zip code is required.';
+    } else if (!isValidZipCode(state.event_cityzip)) {
+      newErrors.event_cityzip = 'Please enter a valid zip code from the St. Louis metro area.';
+    }
     if (!state.event_price || isNaN(state.event_price) || state.event_price <= 0) {
       newErrors.event_price = 'Event price must be a positive number.';
     }

--- a/EventFinder-UI/src/components/Dashboard.jsx
+++ b/EventFinder-UI/src/components/Dashboard.jsx
@@ -59,7 +59,8 @@ const formatTime = (time) => {
                 <th>Event Category</th>
                 <th>Event Date</th>
                 <th>Event Time</th>
-                <th>Event Location</th>
+                <th>Event Venue</th>
+                <th>City and Zip Code</th>
                 <th>Event Price</th>
                 <th>Actions</th>  
               </tr>

--- a/EventFinder-UI/src/components/Dashboard.jsx
+++ b/EventFinder-UI/src/components/Dashboard.jsx
@@ -75,6 +75,7 @@ const formatTime = (time) => {
                   <td>{new Date(event.eventDate).toLocaleDateString()}</td>
                   <td>{formatTime(event.eventTime)}</td>
                   <td>{event.eventLocation}</td>
+                  <td>{event.eventCityzip}</td>
                   <td>{event.eventPrice}</td>
                   <td>
                     <button onClick={() => handleRemove(event.id)} className="button-remove">

--- a/EventFinder-UI/src/components/EventDetails.jsx
+++ b/EventFinder-UI/src/components/EventDetails.jsx
@@ -15,6 +15,7 @@ const EventDetails = () => {
         startDate: '',
         endDate: '',
         location: '',
+        cityzip: '',
         minPrice: '',
         maxPrice: ''
     });
@@ -68,6 +69,11 @@ const EventDetails = () => {
             filtered = filtered.filter(event => event.eventLocation.toLowerCase().includes(filters.location.toLowerCase()));
         }
 
+        // Apply cityzip filter
+        if (filters.cityzip) {
+            filtered = filtered.filter(event => event.eventCityzip.toLowerCase().includes(filters.cityzip.toLowerCase()));
+        }
+
         // Apply price range filter (assuming events have a price field)
         if (filters.minPrice && filters.maxPrice) {
             filtered = filtered.filter(event =>
@@ -92,6 +98,7 @@ const EventDetails = () => {
             const filtered = data.filter(event =>
                 event.eventName.toLowerCase().includes(searchTerm.toLowerCase()) ||
                 event.eventLocation.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                event.eventcityzip.toLowerCase().includes(searchTerm.toLowerCase()) ||
                 event.eventCategory.toLowerCase().includes(searchTerm.toLowerCase())
             );
             setFilteredData(filtered); // Update filteredData based on search term
@@ -105,6 +112,7 @@ const EventDetails = () => {
             startDate: '',
             endDate: '',
             location: '',
+            cityzip: '',
             minPrice: '',
             maxPrice: ''
         });
@@ -188,6 +196,15 @@ const EventDetails = () => {
                             />
                         </div>
                         <div className='col-md-3'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                placeholder='Zip Code'
+                                value={filters.cityzip}
+                                onChange={(e) => setFilters({ ...filters, cityzip: e.target.value })}
+                            />
+                        </div>
+                        <div className='col-md-3'>
                             <div className='input-group'>
                                 <span className='input-group-text'>$</span>
                                 <input
@@ -226,7 +243,8 @@ const EventDetails = () => {
                                         <h5 className='card-title'>{event.eventName}</h5>
                                         <p className='card-text'><strong>Date:</strong> {new Date(event.eventDate).toLocaleDateString()}</p>
                                         <p className='card-text'><strong>Time:</strong> {formatTime(event.eventTime)}</p>
-                                        <p className='card-text'><strong>Location:</strong> {event.eventLocation}</p>
+                                        <p className='card-text'><strong>Venue:</strong> {event.eventLocation}</p>
+                                        <p className='card-text'><strong>City and Zip Code:</strong> {event.eventCityzip}</p>
                                         <p className='card-text'><strong>Description:</strong> {event.description}</p>
                                         <p className='card-text'><strong>Category:</strong> {event.eventCategory}</p>
                                         <p className='card-text'><strong>Price:</strong> ${event.eventPrice.toFixed(2)}</p>

--- a/EventFinder-UI/src/components/Weather.jsx
+++ b/EventFinder-UI/src/components/Weather.jsx
@@ -55,7 +55,7 @@ const Weather = () => {
                                 <p>Loading...</p>
                             ) : weatherData ? (
                                 <div>
-                                    <p>In {weatherData.location}</p>
+                                    <p>In {weatherData.destination}, {zipCode}</p>
                                     <p>The temperature in the next three hours is expected to be: {weatherData.temp} °F</p>
                                 </div>
                             ) : (

--- a/event-finder-API/src/main/java/org/launchcode/event_finder/Controllers/AdminController.java
+++ b/event-finder-API/src/main/java/org/launchcode/event_finder/Controllers/AdminController.java
@@ -48,6 +48,7 @@ public class AdminController {
             existingEvent.setEventDate(event.getEventDate( ));
             existingEvent.setEventTime(event.getEventTime( ));
             existingEvent.setEventLocation(event.getEventLocation( ));
+            existingEvent.setEventCityzip(event.getEventCityzip( ));
             existingEvent.setDescription(event.getDescription( ));
             existingEvent.setEventCategory(event.getEventCategory());
             existingEvent.setEventPrice(event.getEventPrice());
@@ -76,6 +77,7 @@ public class AdminController {
             @RequestParam("eventDate")@DateTimeFormat(pattern = "yyyy-MM-dd") Date eventDate,
             @RequestParam("eventTime") LocalTime eventTime,
             @RequestParam("eventLocation") String eventLocation,
+            @RequestParam("eventCityzip") String eventCityzip,
             @RequestParam("description") String description,
             @RequestParam("eventCategory") String eventCategory,
             @RequestParam("eventPrice") double eventPrice,
@@ -87,6 +89,7 @@ public class AdminController {
         event.setEventDate(eventDate);
         event.setEventTime(eventTime);
         event.setEventLocation(eventLocation);
+        event.setEventCityzip(eventCityzip);
         event.setDescription(description);
         event.setEventCategory(eventCategory);
         event.setEventPrice(eventPrice);

--- a/event-finder-API/src/main/java/org/launchcode/event_finder/Models/DTO/WeatherDTO.java
+++ b/event-finder-API/src/main/java/org/launchcode/event_finder/Models/DTO/WeatherDTO.java
@@ -1,16 +1,16 @@
 package org.launchcode.event_finder.Models.DTO;
 
 public class WeatherDTO {
-    private String location;
+    private String destination;
     private double temp;
 
     // Getters and setters
-    public String getLocation() {
-        return location;
+    public String getDestination() {
+        return destination;
     }
 
-    public void setLocation(String location) {
-        this.location = location;
+    public void setDestination(String destination) {
+        this.destination = destination;
     }
 
     public double getTemp() {

--- a/event-finder-API/src/main/java/org/launchcode/event_finder/Models/Event.java
+++ b/event-finder-API/src/main/java/org/launchcode/event_finder/Models/Event.java
@@ -33,8 +33,11 @@ public class Event {
     @NotNull(message = "Please Enter Event Time.")
     private LocalTime eventTime;
 
-    @NotBlank(message = "Event location must not be empty")
+    @NotBlank(message = "Event venue must not be empty")
     private String eventLocation;
+
+    @NotBlank(message = "Event zip code must not be empty")
+    private String eventCityzip;
 
     @NotBlank(message = "Please provide Event Description.")
     @Size(min=5, message = "Description must be at least 5 characters.")
@@ -118,6 +121,14 @@ public class Event {
 
     public void setEventLocation(String eventLocation) {
         this.eventLocation = eventLocation;
+    }
+
+    public String getEventCityzip() {
+        return eventCityzip;
+    }
+
+    public void setEventCityzip(String eventCityzip) {
+        this.eventCityzip = eventCityzip;
     }
 
     public String getDescription() {

--- a/event-finder-API/src/main/java/org/launchcode/event_finder/Models/WeatherApiResponse.java
+++ b/event-finder-API/src/main/java/org/launchcode/event_finder/Models/WeatherApiResponse.java
@@ -58,7 +58,7 @@ public class WeatherApiResponse {
                 this.temp = temp;
             }
         }
-
+// Not using "description" yet... but likely to add this and other key/value pairs
         public static class Weather {
             private String description;
 

--- a/event-finder-API/src/main/java/org/launchcode/event_finder/Services/WeatherService.java
+++ b/event-finder-API/src/main/java/org/launchcode/event_finder/Services/WeatherService.java
@@ -29,7 +29,7 @@ public class WeatherService {
 
     private WeatherDTO mapToWeatherDTO(WeatherApiResponse apiResponse) {
         WeatherDTO weatherDTO = new WeatherDTO();
-        weatherDTO.setLocation(apiResponse.getCity().getName());
+        weatherDTO.setDestination(apiResponse.getCity().getName());
         weatherDTO.setTemp(apiResponse.getList().get(0).getMain().getTemp());
         return weatherDTO;
     }


### PR DESCRIPTION
Because old data couldn't accept a zip code input, the validation rules for this branch may cause trouble. I truncated all my tables and added the value "1" through a manual query in mySQL. I was then able to register an admin and users and create events with zip code validation in place.

Added zipCode field to create event form. Also added to edit event form in AdminDashboard.

In my testing, I met all of these criteria:

- Change "location" field to "venue name"
- Add "Zip code" field to create form
- Add validation so only STL metro zip codes are accepted
- Displays in both User Dashboard and Admin Dashboard.
- Admin can delete and edit events as before.

Done: Displays venue name, location name and zip code on event details view. Displays error message if nonvalid string is entered in zip code field.