### PR TITLE
53 add get forecast functionality

### DIFF
--- a/EventFinder-UI/src/App.jsx
+++ b/EventFinder-UI/src/App.jsx
@@ -91,8 +91,7 @@ function App() {
           <Route path="/register" element={<RegistrationForm />} />
           <Route path="/login" element={<LoginForm />} />
           <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
-          <Route path="/weather" element={<Weather />} />
-          
+          <Route path="/weather/:zipCode" element={<Weather />} />
           <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />
           <Route path="/create-event" element={<CreateEvent />} />
           <Route path="*" element={<Navigate to="/" />} />

--- a/EventFinder-UI/src/components/AdminDashboard.jsx
+++ b/EventFinder-UI/src/components/AdminDashboard.jsx
@@ -218,7 +218,7 @@ class AdminDashboard extends Component {
                   <th>Event Date</th>
                   <th>Event Time</th>
                   <th>Event Venue</th>
-                  <th>Event City and Zip Code</th>
+                  <th>Event Zip Code</th>
                   <th>Event Price</th>
                   <th>Approval Status</th>
                   <th>Actions</th>
@@ -315,7 +315,7 @@ class AdminDashboard extends Component {
                     {editErrors.eventLocation && <span className="error">{editErrors.eventLocation}</span>} 
                   </label><br />
                   <label>
-                    Event City and Zip Code:
+                    Event Zip Code:
                     <input type="text" name="eventCityzip" value={editEvent.eventCityzip} onChange={this.handleInputChange} />
                     {editErrors.eventCityzip && <span className="error">{editErrors.eventCityzip}</span>} 
                   </label><br />

--- a/EventFinder-UI/src/components/CreateEvent.jsx
+++ b/EventFinder-UI/src/components/CreateEvent.jsx
@@ -155,7 +155,7 @@ const CreateEvent = () => {
           {errors.event_location && <span className="error">{errors.event_location}</span>}
         </label>
         <label>
-          Event City and Zip Code:
+          Event Zip Code:
           <input 
           type="text" 
           name="event_cityzip" 

--- a/EventFinder-UI/src/components/Dashboard.jsx
+++ b/EventFinder-UI/src/components/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
 import axios from 'axios';
 import '../styles/Dashboard.css';
@@ -9,7 +9,6 @@ const Dashboard = () => {
   const { user, favorites, fetchFavorites, removeFavorite } = useAuth();
   const [rsvpStatuses, setRsvpStatuses] = useState({}); // State to store RSVP statuses
   const [showRsvpPopup, setShowRsvpPopup] = useState(null); // State to manage RSVP popup visibility
-  const history = useHistory();
 
   useEffect(() => {
     if (user) {
@@ -59,7 +58,7 @@ const Dashboard = () => {
   };
 
   const handleGetForecast = (zipCode) => {
-    history.push(`/weather/${zipCode}`);
+    navigate(`/weather/${zipCode}`);
   };
 
   const formatTime = (time) => {
@@ -124,7 +123,7 @@ const Dashboard = () => {
                     </button>
                     <button
                       onClick={() => handleGetForecast(event.eventCityzip)}
-                      className="button-forecast"
+                      className="button-rsvp"
                       >
                       Get Forecast
                     </button>

--- a/EventFinder-UI/src/components/Dashboard.jsx
+++ b/EventFinder-UI/src/components/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useHistory } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
 import axios from 'axios';
 import '../styles/Dashboard.css';
@@ -9,6 +9,7 @@ const Dashboard = () => {
   const { user, favorites, fetchFavorites, removeFavorite } = useAuth();
   const [rsvpStatuses, setRsvpStatuses] = useState({}); // State to store RSVP statuses
   const [showRsvpPopup, setShowRsvpPopup] = useState(null); // State to manage RSVP popup visibility
+  const history = useHistory();
 
   useEffect(() => {
     if (user) {
@@ -57,6 +58,10 @@ const Dashboard = () => {
     }
   };
 
+  const handleGetForecast = (zipCode) => {
+    history.push(`/weather/${zipCode}`);
+  };
+
   const formatTime = (time) => {
     try {
       if (!Array.isArray(time) || time.length !== 2) {
@@ -89,7 +94,7 @@ const Dashboard = () => {
                 <th>Event Date</th>
                 <th>Event Time</th>
                 <th>Event Venue</th>
-                <th>City and Zip Code</th>
+                <th>Zip Code</th>
                 <th>Event Price</th>
                 <th>RSVP Status</th>
                 <th>Actions</th>
@@ -116,6 +121,12 @@ const Dashboard = () => {
                       className="button-rsvp"
                     >
                       RSVP
+                    </button>
+                    <button
+                      onClick={() => handleGetForecast(event.eventCityzip)}
+                      className="button-forecast"
+                      >
+                      Get Forecast
                     </button>
                     <button
                       onClick={() => handleRemove(event.id)}

--- a/EventFinder-UI/src/components/Dashboard.jsx
+++ b/EventFinder-UI/src/components/Dashboard.jsx
@@ -123,7 +123,7 @@ const Dashboard = () => {
                     </button>
                     <button
                       onClick={() => handleGetForecast(event.eventCityzip)}
-                      className="button-rsvp"
+                      className="button-weather"
                       >
                       Get Forecast
                     </button>

--- a/EventFinder-UI/src/components/EventDetails.jsx
+++ b/EventFinder-UI/src/components/EventDetails.jsx
@@ -313,7 +313,7 @@ const EventDetails = () => {
                                         <p className='card-text'><strong>Date:</strong> {new Date(event.eventDate).toLocaleDateString()}</p>
                                         <p className='card-text'><strong>Time:</strong> {formatTime(event.eventTime)}</p>
                                         <p className='card-text'><strong>Venue:</strong> {event.eventLocation}</p>
-                                        <p className='card-text'><strong>City and Zip Code:</strong> {event.eventCityzip}</p>
+                                        <p className='card-text'><strong>Zip Code:</strong> {event.eventCityzip}</p>
                                         <p className='card-text'><strong>Description:</strong> {event.description}</p>
                                         <p className='card-text'><strong>Category:</strong> {event.eventCategory}</p>
                                         <p className='card-text'><strong>Price:</strong> ${event.eventPrice.toFixed(2)}</p>

--- a/EventFinder-UI/src/components/NavBar.jsx
+++ b/EventFinder-UI/src/components/NavBar.jsx
@@ -16,7 +16,6 @@ const NavBar = () => {
             )}
             <li><Link to="/dashboard">Dashboard</Link></li>
             <li><a href="#logout" onClick={logout}>Logout</a></li>
-            <li><Link to="/weather">Weather</Link></li>
           </>
         ) : (
           <>

--- a/EventFinder-UI/src/components/Weather.jsx
+++ b/EventFinder-UI/src/components/Weather.jsx
@@ -41,7 +41,7 @@ const Weather = () => {
                                 </div>
                             ) : (
                                 <div>
-                                    <p>Currenlty, no weather data is available for {weatherData.destination}, {zipCode}</p>
+                                    <p>Currently, no weather data is available for {weatherData.destination}, {zipCode}</p>
                                     <p>Please try again later.</p>
                                 </div>
                             )}

--- a/EventFinder-UI/src/components/Weather.jsx
+++ b/EventFinder-UI/src/components/Weather.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/Weather.css';
@@ -9,21 +9,20 @@ const Weather = () => {
     const [weatherData, setWeatherData] = useState(null);
     const [loading, setLoading] = useState(false);
 
-    const getWeather = (zipCode) => {
-
-        setLoading(true);
-
-        getWeather(zipCode)
-            .then((data) => {
-                setWeatherData(data);
-                setLoading(false); 
-            })
-            .catch((error) => {
-                console.error('Error fetching weather data:', error);
-                setLoading(false);
-            });
-
-    };
+    useEffect(() => {
+        if (zipCode) {
+            setLoading(true);
+            getWeather(zipCode)
+                .then((data) => {
+                    setWeatherData(data);
+                    setLoading(false); 
+                })
+                .catch((error) => {
+                    console.error('Error fetching weather data:', error);
+                    setLoading(false);
+                });
+        }
+    }, [zipCode]);     
 
     return (
         <div className='container py-5'>
@@ -34,16 +33,13 @@ const Weather = () => {
                         <div className="mt-4">
                             {loading ? (
                                 <p>Loading...</p>
-                            ) :  weatherData ? (
+                            ) : weatherData ? (
                                 <div>
                                     <p>In {weatherData.destination}, {zipCode}</p>
                                     <p>The temperature in the next three hours is expected to be: {weatherData.temp} °F</p>
                                 </div>
                             ) : (
-                                <div>
-                                    <p>Currently, no weather data is available for {weatherData.destination}, {zipCode}</p>
-                                    <p>Please try again later.</p>
-                                </div>
+                                <p>We're sorry--weather information is currently unavailable. Please try again later.</p>
                             )}
                         </div>
                     </div>

--- a/EventFinder-UI/src/components/Weather.jsx
+++ b/EventFinder-UI/src/components/Weather.jsx
@@ -1,40 +1,28 @@
 import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/Weather.css';
 import { getWeather } from '../services/WeatherService';
-import STL_METRO_ZIPS from '../utilities/MetroZipCodes';
 
 const Weather = () => {
+    const {zipCode} = useParams();
     const [weatherData, setWeatherData] = useState(null);
-    const [zipCode, setZipCode] = useState('');
     const [loading, setLoading] = useState(false);
 
-    const isValidZipCode = (zipCode) => {
-        return STL_METRO_ZIPS.includes(zipCode);
-    };
-
-    const handleGetWeather = () => {
-        if (zipCode.trim() === '') {
-            console.error('Please enter a valid zip code.');
-            return;
-        }
+    const getWeather = (zipCode) => {
 
         setLoading(true);
 
-        if (isValidZipCode(zipCode)) {
-            getWeather(zipCode)
-                .then((data) => {
-                    setWeatherData(data);
-                    setLoading(false); 
-                })
-                .catch((error) => {
-                    console.error('Error fetching weather data:', error);
-                    setLoading(false);
-                });
-        } else {
-            alert('Please enter a valid zip code from the St. Louis metro area.');
-            setLoading(false); 
-        }
+        getWeather(zipCode)
+            .then((data) => {
+                setWeatherData(data);
+                setLoading(false); 
+            })
+            .catch((error) => {
+                console.error('Error fetching weather data:', error);
+                setLoading(false);
+            });
+
     };
 
     return (
@@ -43,23 +31,19 @@ const Weather = () => {
                 <div className='card-body'>
                     <div className='mb-3'>
                         <h1 className='text-primary'>Event Weather</h1>
-                        <input 
-                            type="text" 
-                            placeholder="Enter zip code" 
-                            value={zipCode} 
-                            onChange={(e) => setZipCode(e.target.value)}
-                        />
-                        <button onClick={handleGetWeather} className="btn btn-primary mt-2">Get Weather</button>
                         <div className="mt-4">
                             {loading ? (
                                 <p>Loading...</p>
-                            ) : weatherData ? (
+                            ) :  weatherData ? (
                                 <div>
                                     <p>In {weatherData.destination}, {zipCode}</p>
                                     <p>The temperature in the next three hours is expected to be: {weatherData.temp} °F</p>
                                 </div>
                             ) : (
-                                <p>Please enter a zip code to get the weather information.</p>
+                                <div>
+                                    <p>Currenlty, no weather data is available for {weatherData.destination}, {zipCode}</p>
+                                    <p>Please try again later.</p>
+                                </div>
                             )}
                         </div>
                     </div>

--- a/EventFinder-UI/src/styles/Dashboard.css
+++ b/EventFinder-UI/src/styles/Dashboard.css
@@ -46,7 +46,8 @@
   
   /* Action buttons within the table */
   .button-rsvp,
-  .button-remove {
+  .button-remove,
+  .button-weather {
     padding: 8px 12px;
     margin: 4px;
     border: none;
@@ -64,6 +65,16 @@
   
   .button-rsvp:hover {
     background-color: #45a049;
+  }
+
+  /* Weather Button Styling */
+  .button-weather {
+    background-color: #4605eb;
+    color: white;
+  }
+  
+  .button-weather:hover {
+    background-color: #0778ea;
   }
   
   /* Delete Button Styling */


### PR DESCRIPTION
"Get Forecast" button links users from a single event in their saved favorites to a forecast page that automatically displays the forecast by the zip code associated with the event.

- Added button under Actions column in favorites view of user dashboard, styled
- Added get forecast by zipcode associated with the event on click
- Redirects user to Event Weather page on click
- Renamed Event Weather page to Event Forecast page and remove user submission by zip code
- Removed Event Weather links from NavBar

Definition of done:
Event Forecast page displays only on click in Actions column for a given favorite event saved to user dashboard. Event Forecast page displays correct zip code and location name, with corresponding forecast. Users no longer see Event Weather submission form or Event Weather navigation in the navbar.