### PR TITLE
Approved events display on home page

### DIFF
--- a/EventFinder-UI/src/components/EventDetails.jsx
+++ b/EventFinder-UI/src/components/EventDetails.jsx
@@ -19,7 +19,8 @@ const EventDetails = () => {
         location: '',
         cityzip: '',
         minPrice: '',
-        maxPrice: ''
+        maxPrice: '',
+        approvalStatus: ''
     });
     const [rsvpStatuses, setRsvpStatuses] = useState({}); // State to manage RSVP status
     const { user, addFavorite, removeFavorite, } = useAuth(); // Get user and addFavorite from AuthContext
@@ -74,8 +75,13 @@ const EventDetails = () => {
         axios.get('http://localhost:8080/api/events')
             .then(res => {
                 console.log('Fetched data:', res.data); // Log the fetched data
-                setData(res.data); // Set fetched data to state
-                setFilteredData(res.data); // Initially set filteredData to all data
+                // ieva changed the fetch code, see below:
+                // Former code: setData(res.data); // Set fetched data to state
+                // Former code: setFilteredData(res.data); // Initially set filteredData to all data
+                // New code to lmit home page content to moderated events only
+                const approvedEvents = res.data.filter(event => event.approvalStatus === 'Approved');
+                setData(approvedEvents); // Set approved fetched data to state
+                setFilteredData(approvedEvents); // Initially set filteredData to approved data
             })
             .catch(err => {
                 console.error('Error fetching data:', err);


### PR DESCRIPTION
The home page view was showing all pending, rejected, and approved events.
All user submitted events begin with a default approval status of pending, which they cannot edit.
Admins can review pending submissions and reject any with inappropriate content.

Added code to display only the approved events on the home page, so that no inappropriate content can be displayed, RSVP'd to, or added to favorites.

NOTE: if you have rejected events saved to favorites, this branch will not clear them out. New users would not be in this situation.